### PR TITLE
Support negative integers

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ Compile the fizzbuzz module:
 
 `> c(fizzbuzz).`
 
-Run fizzbuzz computation from 1 up to any positive integer N:
+Run fizzbuzz computation either from 1 up to any positive integer N or from -1 to any negative integer N:
 
 ```
-> fizzbuzz:up_to(10).
+> fizzbuzz:to(15).
 1
 2
 3 fizz
@@ -32,4 +32,23 @@ Run fizzbuzz computation from 1 up to any positive integer N:
 13
 14
 15 fizzbuzz
+```
+
+```
+> fizzbuzz:to(-15).
+-1
+-2
+-3 fizz
+-4
+-5 buzz
+-6 fizz
+-7
+-8
+-9 fizz
+-10 buzz
+-11
+-12 fizz
+-13
+-14
+-15 fizzbuzz
 ```

--- a/fizzbuzz.erl
+++ b/fizzbuzz.erl
@@ -13,7 +13,6 @@ to(N) ->
                   end, Numbers),
     wait(abs(N)).
 
-%% @deprecated Please use {@link fizzbuzz:to/1} instead.
 up_to(N) ->
     Self = self(),
     lists:foreach(fun(M) ->

--- a/fizzbuzz.erl
+++ b/fizzbuzz.erl
@@ -1,4 +1,5 @@
 -module(fizzbuzz).
+-deprecated({up_to, 1}).
 
 -export([to/1,
          up_to/1,

--- a/fizzbuzz.erl
+++ b/fizzbuzz.erl
@@ -1,7 +1,16 @@
 -module(fizzbuzz).
 
--export([up_to/1,
+-export([to/1,
+         up_to/1,
          fizzbuzz/2]).
+
+to(N) ->
+    Self = self(),
+    Numbers = if N < 0 -> lists:seq(-1, N, -1); true -> lists:seq(1, N) end,
+    lists:foreach(fun(M) ->
+                          spawn_link(?MODULE, fizzbuzz, [Self, M])
+                  end, Numbers),
+    wait(abs(N)).
 
 up_to(N) ->
     Self = self(),

--- a/fizzbuzz.erl
+++ b/fizzbuzz.erl
@@ -12,6 +12,7 @@ to(N) ->
                   end, Numbers),
     wait(abs(N)).
 
+%% @deprecated Please use {@link fizzbuzz:to/1} instead.
 up_to(N) ->
     Self = self(),
     lists:foreach(fun(M) ->


### PR DESCRIPTION
Hi,

here's a proposed implementation for supporting negative integers.

I noticed that `up_to` wouldn't sound good anymore when it's certain that the input will be negative, so I aliased `up_to` to `up_from` for those cases. This makes the usage look like `fizzbuzz:up_to(123). fizzbuzz:up_from(-123).`. I hope this is fine.